### PR TITLE
fix: add CommonJS mock bucket implementation

### DIFF
--- a/mock/bucket.js
+++ b/mock/bucket.js
@@ -1,0 +1,35 @@
+const data = require('../bucket.json').bucket;
+
+function parseFields(fields = []) {
+  const metadata = {};
+  fields.forEach(field => {
+    metadata[field.key] = field.value;
+  });
+  return metadata;
+}
+
+module.exports = {
+  async getObjects() {
+    const objects = (data.objects || []).map(obj =>
+      Object.assign({}, obj, { metadata: parseFields(obj.metafields) })
+    );
+    return { objects };
+  },
+
+  async getObject(params = {}) {
+    const slug = params.slug;
+    const object = (data.objects || []).find(o => o.slug === slug);
+    return {
+      object: object
+        ? Object.assign({}, object, { metadata: parseFields(object.metafields) })
+        : null
+    };
+  },
+
+  async addObject(newObj = {}) {
+    const object = Object.assign({}, newObj, {
+      metadata: parseFields(newObj.metafields || [])
+    });
+    return { object };
+  }
+};


### PR DESCRIPTION
## Summary
- add mock bucket module exporting getObjects/getObject/addObject
- replace object spread with `Object.assign` to build objects metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NODE_ENV=production node app.js`

------
https://chatgpt.com/codex/tasks/task_e_689d3400487c833087ca925481d49427